### PR TITLE
fixing bad firestore imports

### DIFF
--- a/packages/apollo-link-firebase-firestore/src/test/queryResolver.test.ts
+++ b/packages/apollo-link-firebase-firestore/src/test/queryResolver.test.ts
@@ -1,5 +1,5 @@
 import {pascalCase} from 'change-case';
-import {firestore} from 'firebase';
+import {firestore} from 'firebase/app';
 import {
   queryResolver,
   refForPath,

--- a/packages/apollo-link-firebase-firestore/src/test/utilities.ts
+++ b/packages/apollo-link-firebase-firestore/src/test/utilities.ts
@@ -1,6 +1,6 @@
 // istanbul ignore file
 
-import {firestore} from 'firebase';
+import {firestore} from 'firebase/app';
 
 export function mockFirestore(props: Partial<firestore.Firestore> = {}) {
   return {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,1 +1,1 @@
-export {};
+import 'firebase/firestore';


### PR DESCRIPTION
firestore imports should be from `firebase/app` not `firebase`